### PR TITLE
Add React Kanban board project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+/dist
+.env

--- a/README.md
+++ b/README.md
@@ -1,1 +1,13 @@
-Test
+# Kanban Board
+
+This project is a simple drag-and-drop Kanban board built with React, TypeScript and Vite. UI components are styled with Tailwind CSS using shadcn conventions.
+
+## Available Scripts
+
+- `npm run dev` – start the development server
+- `npm run build` – create a production build
+- `npm run preview` – preview the production build
+
+## Notes
+
+Dependencies are listed in `package.json`, but they may not be installed in this environment.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Kanban Board</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "kanban-board",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-react": "^4.0.0",
+    "typescript": "^5.0.0",
+    "vite": "^4.0.0",
+    "tailwindcss": "^3.4.0",
+    "autoprefixer": "^10.4.0",
+    "postcss": "^8.4.0"
+  }
+}

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,0 +1,100 @@
+import { useState } from 'react';
+import { Button } from './components/ui/button';
+
+interface Task {
+  id: string;
+  text: string;
+}
+
+interface Column {
+  id: string;
+  title: string;
+  tasks: Task[];
+}
+
+const initialBoard: Column[] = [
+  { id: 'todo', title: 'To Do', tasks: [ { id: '1', text: 'First task' } ] },
+  { id: 'inprogress', title: 'In Progress', tasks: [] },
+  { id: 'done', title: 'Done', tasks: [] },
+];
+
+export default function App() {
+  const [board, setBoard] = useState<Column[]>(initialBoard);
+  const [newTaskId, setNewTaskId] = useState(2);
+
+  const handleDragStart = (
+    e: React.DragEvent<HTMLDivElement>,
+    columnId: string,
+    taskId: string
+  ) => {
+    e.dataTransfer.setData('text/plain', JSON.stringify({ columnId, taskId }));
+  };
+
+  const handleDrop = (
+    e: React.DragEvent<HTMLDivElement>,
+    targetColumnId: string
+  ) => {
+    e.preventDefault();
+    const data = JSON.parse(e.dataTransfer.getData('text/plain')) as {
+      columnId: string;
+      taskId: string;
+    };
+    if (!data) return;
+    setBoard((prev) => {
+      const sourceColumn = prev.find((c) => c.id === data.columnId);
+      const targetColumn = prev.find((c) => c.id === targetColumnId);
+      if (!sourceColumn || !targetColumn) return prev;
+
+      const taskIndex = sourceColumn.tasks.findIndex((t) => t.id === data.taskId);
+      if (taskIndex === -1) return prev;
+
+      const [task] = sourceColumn.tasks.splice(taskIndex, 1);
+      targetColumn.tasks.push(task);
+      return [...prev];
+    });
+  };
+
+  const handleDragOver = (e: React.DragEvent<HTMLDivElement>) => {
+    e.preventDefault();
+  };
+
+  const addTask = () => {
+    setBoard((prev) => {
+      const todo = prev.find((c) => c.id === 'todo');
+      if (!todo) return prev;
+      todo.tasks.push({ id: String(newTaskId), text: `Task ${newTaskId}` });
+      return [...prev];
+    });
+    setNewTaskId((id) => id + 1);
+  };
+
+  return (
+    <div className="flex gap-4 p-4">
+      {board.map((column) => (
+        <div
+          key={column.id}
+          onDragOver={handleDragOver}
+          onDrop={(e) => handleDrop(e, column.id)}
+          className="flex-1 rounded border bg-gray-50 p-2"
+        >
+          <h2 className="mb-2 text-lg font-bold">{column.title}</h2>
+          <div className="space-y-2">
+            {column.tasks.map((task) => (
+              <div
+                key={task.id}
+                draggable
+                onDragStart={(e) => handleDragStart(e, column.id, task.id)}
+                className="cursor-grab rounded bg-white p-2 shadow"
+              >
+                {task.text}
+              </div>
+            ))}
+            {column.id === 'todo' && (
+              <Button onClick={addTask} className="w-full">Add Task</Button>
+            )}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -1,0 +1,20 @@
+import { cn } from '@/lib/utils';
+import { ButtonHTMLAttributes, forwardRef } from 'react';
+
+export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {}
+
+export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ className, ...props }, ref) => {
+    return (
+      <button
+        ref={ref}
+        className={cn(
+          'inline-flex items-center justify-center rounded-md bg-blue-600 px-3 py-1 text-sm font-medium text-white hover:bg-blue-700',
+          className
+        )}
+        {...props}
+      />
+    );
+  }
+);
+Button.displayName = 'Button';

--- a/src/index.css
+++ b/src/index.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,0 +1,3 @@
+export function cn(...classes: (string | undefined)[]) {
+  return classes.filter(Boolean).join(' ');
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+import './index.css';
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,11 @@
+/** @type {import('tailwindcss').Config} */
+export default {
+  content: [
+    './index.html',
+    './src/**/*.{ts,tsx}',
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,25 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": false,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["src/*"]
+    }
+  },
+  "include": ["src"],
+  "references": [{ "path": "./tsconfig.node.json" }]
+}

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+
+export default defineConfig({
+  plugins: [react()],
+});


### PR DESCRIPTION
## Summary
- initialize React+Vite project structure with TypeScript
- add Tailwind config and shadcn-style Button component
- implement basic drag-and-drop Kanban board

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841e5f2ff608324a0c91adb29f8c29a